### PR TITLE
Add child team

### DIFF
--- a/modules/teams/README.md
+++ b/modules/teams/README.md
@@ -22,15 +22,49 @@ Creates a Github team with defined members and corresponding roles.
 |------|------|
 | [github_team.team](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team) | resource |
 | [github_team_membership.members](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership) | resource |
+| [github_team_repository.teams](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | resource |
+| [github_team.parent](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/team) | data |
+
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_description"></a> [description](#input\_description) | n/a | `string` | `null` | no |
-| <a name="input_members"></a> [members](#input\_members) | List of members for the team and their role. For each member:<br>    - username: Github username.<br>    - role: (optional) the role granted to the team member. One of<br>        - member (default)<br>        - maintainer<br>        - owner | <pre>list(object({<br>    username = string<br>    role     = optional(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_parent_team_id"></a> [parent\_team\_id](#input\_parent\_team\_id) | n/a | `number` | `null` | no |
+Code block below represents the JSON input that is need for this module.
+Optional objects can be ignored and not necessary to
+
+``` json
+{
+    "team_name": "Test team",                   //(Mandatory) Name of the Team to be created
+    "description": "Test team",                 //(Optional) Description of the team to be created
+    "team_privacy": "secret",                   //(Optional) Defaulted to `closed` visile to all team members
+    "parent_team_name": "Parent team Name"      //(Optional) Name of the parent team under which new team to be created as child.
+                                                   // Defaulted to standalone team if noparent is provded.
+    "maintainers": [                            //(Optional) Users to be added to team with maintainer role
+      "user1",
+      "user2"
+    ],
+    "members": [                                //(Optional) Users to be added to team with member role
+      "user3",
+      "user4",
+      "user5"
+    ],
+    "repos": {
+      "admin": [                               //(Optional) List of repositories to be added to team with admin permissions
+        "repo1",
+        "repo2"
+      ],
+      "maintain": [                            //(Optional) List of repositories to be added to team with maintain permissions
+        "repo3",
+        "repo4"
+      ],
+      "push": [                                //(Optional) List of repositories to be added to team with push/write permissions
+        "repo5"
+      ],
+      "triage": []                             //(Optional) List of repositories to be added to team with triage permissions
+    }
+}
+
+```
+<br>
 
 ## Outputs
 

--- a/modules/teams/main.tf
+++ b/modules/teams/main.tf
@@ -30,7 +30,7 @@ resource "github_team" "team" {
   name           = local.team_name
   description    = local.team_description
   privacy        = local.team_privacy
-  parent_team_id = var.parent_team_id # needs to be added in input json and get the id using data source
+  parent_team_id = local.parent_team_id
 }
 
 resource "github_team_membership" "members" {

--- a/modules/teams/main.tf
+++ b/modules/teams/main.tf
@@ -15,9 +15,16 @@ locals {
   uniq_members = distinct(concat(local.maintainers, local.members))
   uniq_repos   = distinct(concat(local.admin_repos, local.maintain_repos, local.push_repos, local.triage_repos))
 
+  parent_team_slug = try(lower(replace(local.team_data.parent_team_name, " ", "-")), null)
+  parent_team_id   = try(data.github_team.parent[0].id, null)
+
   team_privacy = try(local.team_data.team_privacy, "closed")
 }
 
+data "github_team" "parent" {
+  count = local.parent_team_slug == null ? 0 : 1
+  slug  = local.parent_team_slug
+}
 
 resource "github_team" "team" {
   name           = local.team_name

--- a/modules/teams/variables.tf
+++ b/modules/teams/variables.tf
@@ -3,16 +3,6 @@ variable "json_file" {
   type        = string
 }
 
-variable "description" {
-  type    = string
-  default = null
-}
-
-variable "parent_team_id" {
-  type    = number
-  default = null
-}
-
 variable "github_token" {
   description = "GitHub access token used to configure the provider"
   type        = string


### PR DESCRIPTION
This change will update the module to include the parent-child team creation capability. 
If any team needs to be created as child team, we need to pass the parent team name as a json object.

Also, Updated readme file to provide a sample json input structure as an example.